### PR TITLE
Add zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,12 @@ RUN apt-get update && \
 		  jq \
 	&& rm -rf /var/lib/apt/lists/*
 
+# zip
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      zip \
+  && rm -rf /var/lib/apt/lists/*
+
 # Chrome & Xvfb
 RUN \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \


### PR DESCRIPTION
**Why?**
Trying to create a `zip` executable in TS. It is to be used in the `web-deploy` pipeline in the `Copy to S3` step when compressing SSR assets.

**Context:**
[Deploy SSR Assets PR](https://github.com/Canva/canva/pull/138875)
[Slack conversation that triggered this PR](https://canva.slack.com/archives/C0146S11QLW/p1604633459368200)